### PR TITLE
Expose GeometryFactory::destroyGeometry()

### DIFF
--- a/src/cpp/geometryfactory.cpp
+++ b/src/cpp/geometryfactory.cpp
@@ -25,6 +25,7 @@ void GeometryFactory::Initialize(Handle<Object> target) {
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "getPrecisionModel", GetPrecisionModel);
     NODE_SET_PROTOTYPE_METHOD(constructor, "getSRID", GetSRID);
+    NODE_SET_PROTOTYPE_METHOD(constructor, "destroy", Destroy);
 
     target->Set(String::NewSymbol("GeometryFactory"), constructor->GetFunction());
 }
@@ -56,4 +57,12 @@ Handle<Value> GeometryFactory::GetPrecisionModel(const Arguments& args) {
     HandleScope scope;
     GeometryFactory *factory = ObjectWrap::Unwrap<GeometryFactory>(args.This());
     return scope.Close(PrecisionModel::New(factory->_factory->getPrecisionModel()));
+}
+
+Handle<Value> GeometryFactory::Destroy(const Arguments& args) {
+  HandleScope scope;
+  GeometryFactory *factory = ObjectWrap::Unwrap<GeometryFactory>(args.This());
+  Geometry *geom = ObjectWrap::Unwrap<Geometry>(args[0]->ToObject());
+  factory->_factory->destroyGeometry(geom->_geom);
+  return Undefined();
 }

--- a/src/cpp/geometryfactory.hpp
+++ b/src/cpp/geometryfactory.hpp
@@ -23,6 +23,7 @@ class GeometryFactory : public ObjectWrap {
 
         static Handle<Value> GetPrecisionModel(const Arguments& args);
         static Handle<Value> GetSRID(const Arguments& args);
+        static Handle<Value> Destroy(const Arguments& args);
 
     protected:
 


### PR DESCRIPTION
Geometry objects apparently never get freed, so I've added the GeometryFactory::destroyGeometry() function to be exposed for use in Node. Let me know if you guys take any issue with naming convention, implementation details, etc. Thanks!
